### PR TITLE
Fix networking config in docker compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ mkdir /opt/formshare/formshare_odata_webapps
 mkdir /opt/formshare/elasticsearch
 mkdir /opt/formshare/elasticsearch/esdata
 mkdir /opt/formshare/elasticsearch/esdata2
-mkdir /opt/formshare/elasticsearch/esdata3
 sudo chmod -R g+w /opt/formshare
 
 # Set enough memory for Elasticsearch

--- a/docker_compose/docker-compose.yml
+++ b/docker_compose/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
     container_name: fses20240213n01
     environment:
-      - network.host=172.28.1.1
+      - network.host=172.28.1.2
       - node.name=fses20240213n01
       - cluster.name=fs-es-cluster
       - discovery.seed_hosts=fses20240213n02
@@ -35,13 +35,13 @@ services:
       - /opt/formshare/elasticsearch/esdata:/usr/share/elasticsearch/data
     networks:
       fsnet:
-        ipv4_address: 172.28.1.1
+        ipv4_address: 172.28.1.2
 
   fses20240213n02:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
     container_name: fses20240213n02
     environment:
-      - network.host=172.28.1.2
+      - network.host=172.28.1.3
       - node.name=fses20240213n02
       - cluster.name=fs-es-cluster
       - discovery.seed_hosts=fses20240213n01
@@ -57,7 +57,7 @@ services:
       - /opt/formshare/elasticsearch/esdata2:/usr/share/elasticsearch/data
     networks:
       fsnet:
-        ipv4_address: 172.28.1.2
+        ipv4_address: 172.28.1.3
 
   formshare_20240213:
     image: qlands/formshare2:20240213
@@ -69,13 +69,13 @@ services:
       FORMSHARE_ADMIN_USER: admin
       FORMSHARE_ADMIN_EMAIL: admin@myserver.com
       FORMSHARE_ADMIN_PASSWORD: my_secure_password
-      ELASTIC_SEARCH_HOST: 172.28.1.1
+      ELASTIC_SEARCH_HOST: 172.28.1.2
       ELASTIC_SEARCH_PORT: 9200
       FORMSHARE_HOST: 172.28.1.4
       FORMSHARE_PORT: 5900
       FORWARDED_ALLOW_IP: 172.28.1.4
       WAIT_HOSTS_TIMEOUT: 360
-      WAIT_HOSTS: 172.28.1.5:3306, 172.28.1.1:9200
+      WAIT_HOSTS: 172.28.1.5:3306, 172.28.1.2:9200
     volumes:
       - /opt/formshare/repository:/opt/formshare_repository
       - /opt/formshare/log:/opt/formshare_log
@@ -95,4 +95,4 @@ networks:
      ipam:
         driver: default
         config:
-          - subnet: 172.32.0.0/16
+          - subnet: 172.28.0.0/16


### PR DESCRIPTION
The networking setup was invalid and did not allow Docker to create a network before starting up containers. This is the minimum set of changes required to get all the containers started.